### PR TITLE
  Fix decimal formatting for price display

### DIFF
--- a/main.py
+++ b/main.py
@@ -363,9 +363,9 @@ if service_list:
                                             old_price = float(existing_contents_obj[metric_name][region_name])
                                             new_price = float(processed_contents[metric_name][region_name])
                                             if old_price < new_price:
-                                                modified_service_detail[sanitized_service_name] += "\n  - Price increased: {} {}  **${}** → **${}** 🤑".format(metric_name, region_name, old_price, new_price)
+                                                modified_service_detail[sanitized_service_name] += "\n  - Price increased: {} {}  **${:.2f}** → **${:.2f}** 🤑".format(metric_name, region_name, old_price, new_price)
                                             elif old_price > new_price:
-                                                modified_service_detail[sanitized_service_name] += "\n  - Price decreased: {} {}  **${}** → **${}** 💸".format(metric_name, region_name, old_price, new_price)
+                                                modified_service_detail[sanitized_service_name] += "\n  - Price decreased: {} {}  **${:.2f}** → **${:.2f}** 💸".format(metric_name, region_name, old_price, new_price)
                                         except:
                                             modified_service_detail[sanitized_service_name] += "\n  - Price changed: {} {} 💰".format(metric_name, region_name)
             else:


### PR DESCRIPTION
This PR addresses a formatting issue where prices with trailing zeros were not displaying correctly. For example, prices like $0.10 were being shown as $0.1, which looks inconsistent and unprofessional in the pricing reports. That's a nice way of saying it was driving me freaking NUTS.

## Changes

 - Updated price formatting in main.py to use .2f format specifier
 - Ensures all prices display with exactly two decimal places
 - Affects both price increase and decrease notifications in the modified services section

## Examples

- Before: $0.1, $1.5, $10.0
- After: $0.10, $1.50, $10.00

This change improves readability and maintains consistency with standard currency formatting conventions. And again, drives me less nuts. 